### PR TITLE
Catch all for errors

### DIFF
--- a/metadefender.py
+++ b/metadefender.py
@@ -292,7 +292,7 @@ class MetaDefender(ServiceBase):
             self.nodes[self.current_node]['timeout_count'] = 0
             self.nodes[self.current_node]['timeout'] = 0
         else:
-            raise RecoverableError(f"Unable to scan file due to {r.json()['err']}")
+            raise Exception(f"Unable to scan file due to {r.json()['err']}")
         return r.json()
 
     def parse_results(self, response: Dict[str, Any]):

--- a/metadefender.py
+++ b/metadefender.py
@@ -291,7 +291,7 @@ class MetaDefender(ServiceBase):
 
             self.nodes[self.current_node]['timeout_count'] = 0
             self.nodes[self.current_node]['timeout'] = 0
-        elif r.status_code == requests.codes.bad:
+        else:
             raise RecoverableError(f"Unable to scan file due to {r.json()['err']}")
         return r.json()
 


### PR DESCRIPTION
This line was causing all errors that weren't 400 to slip by undetected, which is bad. Now the service will raise an exception for all error codes.