### PR TITLE
Removed specific RAM

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -40,6 +40,6 @@ heuristics:
     description: MetaDefender Antivirus hit.
 
 docker_config:
+  allow_internet_access: true
   image: ${REGISTRY}cccs/assemblyline-service-metadefender:$SERVICE_TAG
   cpu_cores: 0.25
-  ram_mb: 256


### PR DESCRIPTION
Specific RAM value of 256Mb is not enough for some samples over 85Mb and the service will pre-empt. By allowing the default range of 128-512Mb, these samples are able to be analyzed.

Also adding internet access as a default since this is required for AL to reach MD.